### PR TITLE
Fix oc server sbatch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@
 # Do not change httpstan and pystan. You are going to regret it!
 httpstan==4.7.1
 pystan==3.4.0
-numpy~=1.21.5
+numpy~=1.22.4
 scipy~=1.7.1
 matplotlib~=3.4.3
 seaborn~=0.11.2
@@ -26,6 +26,7 @@ sklearn-genetic-opt~=0.8.0
 optuna~=3.6.1
 optuna-dashboard~=0.15.1
 pandas~=1.3.4
+protobuf==5.28.3
 mlflow~=1.26.1
 joblib~=1.1.0
 click~=8.0.3

--- a/runs/comparisons/suprb_all_tuning.py
+++ b/runs/comparisons/suprb_all_tuning.py
@@ -43,7 +43,7 @@ def run(problem: str, job_id: str, study_name: str):
     print(f"Problem is {problem}, with job id {job_id}")
 
     X, y = load_dataset(name=problem, return_X_y=True)
-    X, y y_scaler = scale_X_y(X, y)
+    X, y, y_scaler = scale_X_y(X, y)
     X, y = shuffle(X, y, random_state=random_state)
 
     estimator = SupRB(

--- a/runs/comparisons/suprb_all_tuning.py
+++ b/runs/comparisons/suprb_all_tuning.py
@@ -43,7 +43,7 @@ def run(problem: str, job_id: str, study_name: str):
     print(f"Problem is {problem}, with job id {job_id}")
 
     X, y = load_dataset(name=problem, return_X_y=True)
-    X, y = scale_X_y(X, y)
+    X, y y_scaler = scale_X_y(X, y)
     X, y = shuffle(X, y, random_state=random_state)
 
     estimator = SupRB(

--- a/slurm/default.nix
+++ b/slurm/default.nix
@@ -8,12 +8,12 @@ mkShell {
   venvDir = "./_venv";
   # Add dependencies that pip can't fetch here (or that we don't want to
   # install using pip).
-  buildInputs = (with pkgs.python39Packages; [ python39 venvShellHook wheel ])
+  buildInputs = (with pkgs.python310Packages; [ python310 venvShellHook wheel ])
      ++ (import ./system-dependencies.nix { inherit pkgs; });
   postShellHook = ''
     unset SOURCE_DATE_EPOCH
     export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [pkgs.stdenv.cc.cc]}:${pkgs.lib.makeLibraryPath [pkgs.zlib]}:$LD_LIBRARY_PATH"
-    export PYTHONPATH=$venvDir/${python39.sitePackages}:$PYTHONPATH
+    export PYTHONPATH=$venvDir/${python310.sitePackages}:$PYTHONPATH
   '';
   postVenvCreation = ''
     unset SOURCE_DATE_EPOCH

--- a/slurm/default.nix
+++ b/slurm/default.nix
@@ -8,7 +8,8 @@ mkShell {
   venvDir = "./_venv";
   # Add dependencies that pip can't fetch here (or that we don't want to
   # install using pip).
-  buildInputs = (with pkgs.python310Packages; [ python310 venvShellHook wheel ])
+  buildInputs = (with pkgs.python310Packages; [ python310 venvShellHook wheel pip ]) ++ [
+  pkgs.stdenv.cc.cc]
      ++ (import ./system-dependencies.nix { inherit pkgs; });
   postShellHook = ''
     unset SOURCE_DATE_EPOCH
@@ -20,4 +21,3 @@ mkShell {
     pip install -r requirements.txt
   '';
 }
-

--- a/slurm/default_oc_server.sbatch
+++ b/slurm/default_oc_server.sbatch
@@ -13,4 +13,4 @@ dataset="airfoil_self_noise"
 study_name="SupRB - Airfoil"
 
 srun nix-shell $JOB_DIR/slurm/default.nix --command "PYTHONPATH=$JOB_DIR/$PYTHONPATH \
-python $JOB_DIR/$experiment -p $dataset -j $SLURM_JOB_ID" -n $study_name
+python $JOB_DIR/$experiment -p $dataset -j $SLURM_JOB_ID -n $study_name

--- a/slurm/default_oc_server.sbatch
+++ b/slurm/default_oc_server.sbatch
@@ -13,4 +13,4 @@ dataset="airfoil_self_noise"
 study_name="SupRB - Airfoil"
 
 srun nix-shell $JOB_DIR/slurm/default.nix --command "PYTHONPATH=$JOB_DIR/$PYTHONPATH \
-python $JOB_DIR/$experiment -p $dataset -j $SLURM_JOB_ID -n $study_name
+python $JOB_DIR/$experiment -p $dataset -j $SLURM_JOB_ID -n $study_name"

--- a/slurm/default_oc_server.sbatch
+++ b/slurm/default_oc_server.sbatch
@@ -12,4 +12,4 @@ experiment="runs/comparisons/suprb_all_tuning.py"
 dataset="airfoil_self_noise"
 study_name="SupRB - Airfoil"
 
-srun python $JOB_DIR/$experiment -p $dataset -j $SLURM_JOB_ID -n $study_name
+srun nix-shell $JOB_DIR/$experiment -p $dataset -j $SLURM_JOB_ID -n $study_name

--- a/slurm/default_oc_server.sbatch
+++ b/slurm/default_oc_server.sbatch
@@ -10,7 +10,7 @@ JOB_DIR=/data/oc-compute03/$USER/suprb-experimentation
 export PYTHONPATH=${PYTHONPATH}:${JOB_DIR}
 experiment="runs/comparisons/suprb_all_tuning.py"
 dataset="airfoil_self_noise"
-study_name="SupRB - Airfoil"
+study_name="SupRB-Airfoil"
 
 srun nix-shell $JOB_DIR/slurm/default.nix --command "PYTHONPATH=$JOB_DIR/$PYTHONPATH \
 python $JOB_DIR/$experiment -p $dataset -j $SLURM_JOB_ID -n $study_name"

--- a/slurm/default_oc_server.sbatch
+++ b/slurm/default_oc_server.sbatch
@@ -12,4 +12,5 @@ experiment="runs/comparisons/suprb_all_tuning.py"
 dataset="airfoil_self_noise"
 study_name="SupRB - Airfoil"
 
-srun nix-shell $JOB_DIR/$experiment -p $dataset -j $SLURM_JOB_ID -n $study_name
+srun nix-shell $JOB_DIR/slurm/default.nix --command "PYTHONPATH=$JOB_DIR/$PYTHONPATH \
+python $JOB_DIR/$experiment -p $dataset -j $SLURM_JOB_ID" -n $study_name


### PR DESCRIPTION
Fixes https://github.com/heidmic/suprb-experimentation/issues/51

- Upgraded numpy version
- Added protobuf version (default one for python 3.10 would cause errors)
- Added y_scaler to the return params of scale_X_y
- Changed python version for nix shell to 3.10
- Added libstdc++.so.6 explicitely (because it wasn't taking it from the server environment for some unknown reason)
- Removed whitespaces from study_name in default_oc_server.sbatch (otherwise that param will cause errors)
- Updated srun command in default_oc_server.sbatch

